### PR TITLE
Removed the flag from AnalParams constructor. 

### DIFF
--- a/beammap.cpp
+++ b/beammap.cpp
@@ -53,7 +53,9 @@ int main(int nArgs, char* args[])
   }
 
   //setting up the AnalParams, TimePlace, Array, Source, and Telescope
-  AnalParams* ap = new AnalParams(apXml, 1);
+  AnalParams* ap = new AnalParams(apXml);
+  
+  if (!ap->getBeammapping()) ap->BeamMapError("Error in beammap type xml file");
   int nFiles = ap->getNFiles();
   
   //begin loop over input files

--- a/beammap_gui/beammap_gui.cpp
+++ b/beammap_gui/beammap_gui.cpp
@@ -112,7 +112,7 @@ void MainWindow::openApXml(const QString& path)
             // try setup macana
             try {
                 qDebug() << "initialize macana core from" << path;
-                mAnalParams = std::make_unique<AnalParams>(path.toStdString(), 1);
+                mAnalParams = std::make_unique<AnalParams>(path.toStdString());
                 qDebug() << "number of observations:" << mAnalParams->getNFiles();
                 qDebug() << "macana core initialized";
                 // restore the views' look

--- a/include/AnalParams.h
+++ b/include/AnalParams.h
@@ -193,12 +193,13 @@ class AnalParams
   ///cleaning High Order Atm Template
   int tOrder;
 
-  AnalParams(string apXmlFile);
-  AnalParams(string apXmlFile, int beammapping);
+  AnalParams(string apXmlFile);  
+//   AnalParams(string apXmlFile, int beammapping);///Remove this constructor and force to read if is beammap or not from the xml
   AnalParams(AnalParams *ap);
   bool setDataFile(int index);
   bool determineObservatory();
   [[noreturn]] void throwXmlError(string p);
+  [[noreturn]] void BeamMapError(string p);  
   string getObservatory();
   string getTimeVarName();
   const char* getDataFile();
@@ -210,6 +211,7 @@ class AnalParams
   bool getCoaddObservations();
   bool getFitCoadditionToGaussian();
   bool getProduceNoiseMaps();
+  int getBeammapping();
   bool getApplyWienerFilter();
   bool getWienerFilter();
   double getDespikeSigma();

--- a/macanap.cpp
+++ b/macanap.cpp
@@ -53,6 +53,7 @@ int main(int nArgs, char* args[])
   }
   
   AnalParams* ap = new AnalParams(apXml);
+  if (ap->getBeammapping()) ap->BeamMapError("Error in xml file");
   Array *array=NULL;
   TimePlace *timePlace = NULL;
   Source *source = NULL;

--- a/test/AnalParamsTest.cpp
+++ b/test/AnalParamsTest.cpp
@@ -8,7 +8,7 @@ namespace {
 class AnalParamsTest : public ::testing::Test
 {
 protected:
-    AnalParamsTest(): ap(new AnalParams(apXmlFile, 1)) {}
+    AnalParamsTest(): ap(new AnalParams(apXmlFile)) {}
     ~AnalParamsTest() override {delete ap;}
     void SetUp() override {}
     void TearDown() override {}


### PR DESCRIPTION
This pull request addresses #2. Now the constructor reads the xml and decides if is beammap or science map what is requested. Since now it is possible to run the constructor for a beammap xml file from macanap and for a science xml from beammap, an error appears in macanap or beammap if the xml is not correct. 