### PR TITLE
Modified CMakeLists.txt to have the option to create a executable test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,17 @@ find_package(OpenMP)
 find_package(GSL REQUIRED)
 find_package(FFTW3 REQUIRED COMPONENTS DOUBLE SERIAL)
 # TODO: wrap these in imported targets
+include_directories("/usr/local/lib/")
+include_directories("/usr/include/suitesparse/")
+message("blabla" ${CMAKE_MODULE_PATH})
+include_directories("/usr/include/")
+include_directories("/usr/lib/x86_64-linux-gnu/")
+include_directories("/usr/local/include/")
+link_directories("/home/javierzaragoza/Downloads/netcdf-cxx4-4.3.0/cxx4")
+link_directories("/usr/lib/x86_64-linux-gnu/")
+
 find_package(NetCDF REQUIRED COMPONENTS CXX)
+
 find_package(CCFits REQUIRED)  # this one also find cfitsio
 find_package(CXSparse REQUIRED)
 
@@ -161,6 +171,50 @@ foreach(exec ${exec_list})
         )
 endforeach(exec ${exec_list})
 
+
+
+
+
+OPTION(EXEC_TEST "Create execuable test?" OFF)
+##To create executable test write:
+#cmake .. -DEXEC_TEST=ON
+IF (EXEC_TEST)
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()
+
+# Now simply link against gtest or gtest_main as needed. Eg
+add_subdirectory (test)
+
+ENDIF (EXEC_TEST)
 ## docs
 # https://vicrucann.github.io/tutorials/quick-cmake-doxygen/
 #option(BUILD_DOC "Build documentation" ON)
@@ -181,3 +235,6 @@ endforeach(exec ${exec_list})
 #else()
 #  message("Doxygen need to be installed to generate the doxygen documentation")
 #endif()
+
+
+

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+
+file(GLOB SRCS *.cpp)
+
+add_executable(test ${SRCS})
+
+
+target_link_libraries(test macana-core ${link_libraries} gmock_main)
+
+add_test(NAME test COMMAND test)


### PR DESCRIPTION
This pull request addresses #6. Added a CMakeLists.txt.in to macana2 directory to download googletest. At least in ubuntu is the best option I found. By default the executable test is not created. -DEXEC_TEST=ON should be used when cmake is called. 